### PR TITLE
Remove browserslist entries

### DIFF
--- a/examples/angular/.browserslistrc
+++ b/examples/angular/.browserslistrc
@@ -1,5 +1,0 @@
-# For Link SDK, this file must be set to the following in order
-#   to prevent build errors from webpack thinking dynamic imports
-#   are not supported.
-
-last 1 Chrome versions 

--- a/examples/angular/README.md
+++ b/examples/angular/README.md
@@ -18,12 +18,8 @@ See <a href="https://github.com/codatio/sdk-link/tree/main#create-a-new-company"
 
 1. **Set up steps**
    1. Copy <a href="https://github.com/codatio/sdk-link/blob/main/snippets/types.d.ts" target="_blank"> `types.d.ts`</a> to the `/src` directory.
-   2. Create a browserslist using `ng generate config browserslist` and set its content to the following:
-       ```
-       last 1 Chrome versions 
-       ```
-   3. In `tsconfig.json`, set `target` and `module` to `"ESNext"`.
-   4. If you are using content security policy (CSP) headers, you must edit the headers:
+   2. In `tsconfig.json`, set `target` and `module` to `"ESNext"`.
+   3. If you are using content security policy (CSP) headers, you must edit the headers:
       * Add `*.codat.io` to all of `(script-src, style-src, font-src, connect-src, img-src)`, or to `default-src`.
       * Add `unsafe-inline` to `style-src`. Do *not* use a hash because this can change at any time without warning.
   

--- a/examples/angular/README.md
+++ b/examples/angular/README.md
@@ -18,8 +18,7 @@ See <a href="https://github.com/codatio/sdk-link/tree/main#create-a-new-company"
 
 1. **Set up steps**
    1. Copy <a href="https://github.com/codatio/sdk-link/blob/main/snippets/types.d.ts" target="_blank"> `types.d.ts`</a> to the `/src` directory.
-   2. In `tsconfig.json`, set `target` and `module` to `"ESNext"`.
-   3. If you are using content security policy (CSP) headers, you must edit the headers:
+   2. If you are using content security policy (CSP) headers, you must edit the headers:
       * Add `*.codat.io` to all of `(script-src, style-src, font-src, connect-src, img-src)`, or to `default-src`.
       * Add `unsafe-inline` to `style-src`. Do *not* use a hash because this can change at any time without warning.
   

--- a/examples/angular/tsconfig.json
+++ b/examples/angular/tsconfig.json
@@ -16,8 +16,8 @@
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "importHelpers": true,
-    "target": "ESNext",
-    "module": "ESNext",
+    "target": "ES2022",
+    "module": "ES2022",
     "useDefineForClassFields": false,
     "lib": [
       "ES2022",

--- a/examples/next/README.md
+++ b/examples/next/README.md
@@ -23,16 +23,6 @@ For full instructions on getting started with Next.js, see our [embedded link do
 2. **Conditional steps**
    
     - **Extend your type declarations with our types** - If you are using TypeScript, download the <a href="https://github.com/codatio/sdk-link/blob/main/snippets/types.d.ts" target="_blank"> `types.d.ts`</a> file, then copy and paste its contents into a new or existing `.d.ts` file.
-    
-    - **Update browserslist** - If a `browserslist` entry exists in your `package.json` file, you may need to update it with the following entries for production:
-
-      ```js
-      "production": [
-        ">0.2% and supports es6-module",
-        "not dead",
-        "not and_uc >= 0"
-      ],
-      ```
 
     - **Update CSP headers** - If you're using content security policy (CSP) headers, you must edit the headers:
 

--- a/examples/react/README.md
+++ b/examples/react/README.md
@@ -23,16 +23,7 @@ For full instructions on getting started with React, see our [embedded link docu
 2.  **Conditional steps**
     1. **Extend your type declarations with our types (if using TS)** - download the <a href="https://github.com/codatio/sdk-link/blob/main/snippets/types.d.ts" target="_blank"> `types.d.ts`</a> file, then copy and paste its contents into a new or existing `.d.ts` file.
 
-    2. **Update browserslist** - If a `browserslist` entry exists in your `package.json` file, you may need to update it with the following entries for production:
-        ```js
-          "production": [
-            ">0.2% and supports es6-module",
-            "not dead",
-            "not and_uc >= 0"
-          ],
-        ```
-        
-    3. **Update CSP headers** - If you're using content security policy (CSP) headers, you must edit the headers:
+    2. **Update CSP headers** - If you're using content security policy (CSP) headers, you must edit the headers:
     * Add `*.codat.io` to all of `(script-src, style-src, font-src, connect-src, img-src)`, or to `default-src`.
     * Add `unsafe-inline` to `style-src`. Do *not* use a hash because this can change at any time without warning.
     

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -30,9 +30,9 @@
   },
   "browserslist": {
     "production": [
-      ">0.2% and supports es6-module",
+      ">0.2%",
       "not dead",
-      "not and_uc >= 0"
+      "not op_mini all"
     ],
     "development": [
       "last 1 chrome version",

--- a/examples/react/src/components/CodatLink.tsx
+++ b/examples/react/src/components/CodatLink.tsx
@@ -1,5 +1,4 @@
-import {
-  CodatLink as AuthFlow,
+import type {
   ConnectionCallbackArgs,
   ErrorCallbackArgs,
 } from "https://link-sdk.codat.io";
@@ -23,16 +22,23 @@ export const CodatLink: React.FC<CodatLinkProps> = (props) => {
   useEffect(() => {
     const target = componentMount;
     if (target && target.children.length === 0) {
-      new AuthFlow({
-        target,
-        props: {
-          companyId,
-          onConnection,
-          onClose,
-          onFinish,
-          onError,
-        },
-      });
+      // webpackIgnore is a magic comment that prevents webpack from
+      //   parsing this dynamic import. The build will fail otherwise.
+      // See https://webpack.js.org/api/module-methods/#magic-comments
+      import(/* webpackIgnore: true */ "https://link-sdk.codat.io").then(
+        ({ CodatLink }) => {
+          new CodatLink({
+            target,
+            props: {
+              companyId,
+              onConnection,
+              onClose,
+              onFinish,
+              onError,
+            },
+          });
+        }
+      );
     }
     // CodatLink does not support changing props after initialisation.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/examples/svelte/README.md
+++ b/examples/svelte/README.md
@@ -25,16 +25,6 @@ For full instructions on getting started with svelte, see our [embedded link doc
    
     - **Extend your type declarations with our types** - If you are using TypeScript, download the <a href="https://github.com/codatio/sdk-link/blob/main/snippets/types.d.ts" target="_blank"> `types.d.ts`</a> file, then copy and paste its contents into a new or existing `.d.ts` file.
     
-    - **Update browserslist** - If a `browserslist` entry exists in your `package.json` file, you may need to update it with the following entries for production:
-
-      ```js
-      "production": [
-        ">0.2% and supports es6-module",
-        "not dead",
-        "not and_uc >= 0"
-      ],
-      ```
-
     - **Update CSP headers** - If you're using content security policy (CSP) headers, you must edit the headers:
 
       - Add `*.codat.io` to all of `(script-src, style-src, font-src, connect-src, img-src)`, or to `default-src`.

--- a/examples/vue/README.md
+++ b/examples/vue/README.md
@@ -22,14 +22,6 @@ For full instructions on getting started, see our [embedded link documentation](
 
    1. **Extend your type declarations with our types (if using TS).** - download the <a href="https://github.com/codatio/sdk-link/blob/main/snippets/types.d.ts" target="_blank"> `types.d.ts`</a> file, then copy and paste its contents into a new or existing `.d.ts` file.
 
-   2. **Update browserslist.** - If a `browserslist` entry exists in your `package.json` file, you may need to update it with the following entries for production:
-      ```js
-        "production": [
-          ">0.2% and supports es6-module",
-          "not dead",
-          "not and_uc >= 0"
-        ],
-      ```
    3. **Update CSP headers.** If you're using content security policy (CSP) headers, you must edit the headers:
 
    - Add `*.codat.io` to all of `(script-src, style-src, font-src, connect-src, img-src)`, or to `default-src`.


### PR DESCRIPTION
- Remove browserslist entries and instructions. This was previously needed due to webpack being wrong about which browsers support dynamic imports. The webpackIgnore magic comment fixes this.
- Revert target and module in angular tsconfig. Same reasoning as above.